### PR TITLE
More narrow xonshEnvironmentVariable pattern

### DIFF
--- a/syntax/xonsh.vim
+++ b/syntax/xonsh.vim
@@ -4,7 +4,7 @@ endif
 
 runtime! syntax/python.vim syntax/python/*.vim
 
-syntax match xonshEnvironmentVariable "\v\$[A-Za-z_][A-Za-z0-9_]*"
+syntax match xonshEnvironmentVariable "\v\$\h\w*"
 
 highlight default link xonshEnvironmentVariable Constant
 

--- a/syntax/xonsh.vim
+++ b/syntax/xonsh.vim
@@ -4,7 +4,7 @@ endif
 
 runtime! syntax/python.vim syntax/python/*.vim
 
-syntax match xonshEnvironmentVariable "\v\$[^\s\[\(]+"
+syntax match xonshEnvironmentVariable "\v\$[A-Za-z_][A-Za-z0-9_]*"
 
 highlight default link xonshEnvironmentVariable Constant
 


### PR DESCRIPTION
This is my effort to fix issue #1, though it is admittedly imperfect.

The pattern `\v\$\h\w*` is equivalent to the pattern `\v\$[A-Za-z_][0-9A-Za-z_]*`, but is more efficient to compute.

There are variable names that xonsh accepts but are not matched by that pattern, but if I'm not mistaken, an overly narrow pattern won't break the syntax highlighting the way an overly broad one does.